### PR TITLE
support for long TXT records

### DIFF
--- a/lib/resty/dns/server.lua
+++ b/lib/resty/dns/server.lua
@@ -398,7 +398,20 @@ end
 
 
 local function _encode_txt(txt)
-    return char(#txt) .. txt
+    local result
+    local max = 255
+
+    if #txt <= max then
+        result = char(#txt) .. txt
+    else
+        result = ''
+        for i=1, #txt, max do
+            local part = strsub(txt, i, i+max - 1)
+            result = result .. char(#part) .. part
+        end
+    end
+
+    return result
 end
 
 
@@ -570,8 +583,8 @@ function _M.create_txt_answer(self, name, ttl, txt)
     answer.type = TYPE_TXT
     answer.class = CLASS_IN
     answer.ttl = ttl
-    answer.rdlength = strlen(txt) + 1
     answer.rdata = _encode_txt(txt)
+    answer.rdlength = strlen(answer.rdata)
 
     self.response.header.ancount = self.response.header.ancount + 1
     self.response.ansections[self.response.header.ancount] = answer


### PR DESCRIPTION
Add support for TXT records longer than 255 bytes.

Before the  patch:
```
2019/11/01 15:10:43 [error] 16749#16749: *9 lua entry thread aborted: runtime error: ...cal/openresty/site/lualib/resty/dns/server.lua:410: bad argument #1 to 'char' (invalid value)
stack traceback:
coroutine 0:
        [C]: in function 'char'
```

After the patch:
```
$ dig +tries=1 +tcp -p 9953 TXT +multiline +subnet=123.123.123.1/24 @172.172.1.71 website.local

; <<>> DiG 9.11.5-P4-RedHat-9.11.5-4.P4.fc29 <<>> +tries=1 +tcp -p 9953 TXT +multiline +subnet=123.123.123.1/24 @172.172.1.71 website.local
; (1 server found)
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 18968
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;website.local.         IN TXT

;; ANSWER SECTION:
website.local.          300 IN TXT "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor i" "n reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
website.local.          300 IN TXT "c"
website.local.          300 IN TXT "d"

;; Query time: 9 msec
;; SERVER: 172.172.1.71#9953(172.172.1.71)
;; WHEN: Fri Nov 01 11:11:25 EDT 2019
;; MSG SIZE  rcvd: 557
```